### PR TITLE
Remove syntaxcheck attribute

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="vendor/autoload.php"
     colors="true">
     <testsuites>


### PR DESCRIPTION
# Changed log
- Remove the `syntaxcheck` attribute in `phpunit.xml.dist` because this attribute is not allowed.